### PR TITLE
Remove multisampling

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -188,7 +188,6 @@ fn main() {
         )
         .exit_on_esc(true)
         .vsync(true)
-        .samples(16)
     );
 
     let mut app = {


### PR DESCRIPTION
Windows compilation was fairly straightforward once I found the freetype-6 library for Mingw 64.

However, when running the application it would immediatly crash:

```
PS D:\Programming\rust\catchit-rs> cargo run
   Compiling catchit v1.0.0 (file:///D:/Programming/rust/catchit-rs)
     Running `target\debug\catchit.exe`
thread '<main>' panicked at 'called `Result::unwrap()` on an `Err` value: NotSupported', C:/bot/slave/stable-dist-rustc-win-gnu-64/build/src/libcore\result.rs:729
stack backtrace:
   1:           0x691a72 - main
   2:           0x69b103 - main
   3:           0x65e430 - main
   4:           0x65ee27 - main
   5:           0x69ab4a - main
   6:           0x6b6689 - main
   7:           0x454f64 - main
   8:           0x4541c1 - main
   9:           0x442d51
  10:           0x69d83c - main
  11:           0x69d819 - main
  12:           0x69bb7e - main
  13:           0x453ce4 - main
  14:           0x4013b5
  15:           0x4014e8
  16:     0x7ff9a63d13d2 - BaseThreadInitThunk
An unknown error occurred

To learn more, run the command again with --verbose.
```

This is a very cryptic error, but tracing it revealed that is was somewhere in Glutin. I could not pinpoint where it would throw the error, but after some random adjustments to the initialization this commit fixed it.
